### PR TITLE
Use GH_PAGES_DEPLOY_TOKEN for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,19 +35,15 @@ jobs:
     # Only run this job on pushes to the workflow branch
     if: github.event_name == 'push' && github.ref == 'refs/heads/workflow'
     runs-on: ubuntu-latest
-    
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
       - name: Install Dependencies
         run: npm install
-        
       - name: Build
         run: npm run build
-        
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_DEPLOY_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_PAGES_DEPLOY_TOKEN }}
           publish_dir: ./public


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated GitHub Actions workflows for deployment. The token used for GitHub Pages deployment has been changed from `secrets.GITHUB_TOKEN` to `secrets.GH_PAGES_DEPLOY_TOKEN`. This change enhances the security and control over the deployment process.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->